### PR TITLE
UI/UX 개선 및 페르소나 상세 페이지 레이아웃 수정

### DIFF
--- a/app/chat/[personaId]/page.tsx
+++ b/app/chat/[personaId]/page.tsx
@@ -159,12 +159,12 @@ export default function ChatPage({ params }: ChatPageProps) {
           <div className="shrink-0 h-32 sm:h-36 md:h-40 relative border-b border-zinc-100 dark:border-zinc-800 bg-zinc-50/50 dark:bg-zinc-900/50">
             <div className="relative h-full flex justify-between items-center p-3 sm:p-4 md:p-5">
               <div className="flex-1 pr-2 sm:pr-3 md:pr-4 z-10">
-                <h2 className="text-sm sm:text-base md:text-lg font-bold text-zinc-900 dark:text-zinc-50 mb-1 line-clamp-1">
+                <h2 className="text-sm sm:text-base md:text-lg font-bold text-zinc-900 dark:text-zinc-50 mb-1">
                   {persona.name}
                 </h2>
                 {persona.summary && (
-                  <p className="text-xs text-zinc-600 dark:text-zinc-400 leading-relaxed line-clamp-2 sm:line-clamp-3">
-                    {persona.summary}
+                  <p className="text-xs text-zinc-600 dark:text-zinc-400 leading-relaxed">
+                    {persona.summary.split('.')[0] + '.'}
                   </p>
                 )}
               </div>
@@ -182,21 +182,54 @@ export default function ChatPage({ params }: ChatPageProps) {
           {/* 스크롤 가능한 정보 영역 - 토스 스타일 적용 */}
           <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar">
             <div className="px-4 sm:px-5 py-4 sm:py-5 space-y-4 sm:space-y-6">
-              {/* 인사이트 카드 - 토스 스타일 적용 */}
-              {persona.insight && (
+              {/* 성격 및 말투 - 토스 스타일 적용 */}
+              {persona.persona_character && (
                 <div className="pb-4 sm:pb-5 border-b border-zinc-100 dark:border-zinc-800">
                   <h3 className="text-xs sm:text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-2">
-                    내 인사이트
+                    프로필
                   </h3>
-                  <p className="text-xs sm:text-sm leading-relaxed text-zinc-700 dark:text-zinc-300 py-2.5 sm:py-3 px-3 sm:px-4 bg-zinc-50 dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800">
-                    "{persona.insight}"
-                  </p>
+                  <div className="text-xs sm:text-sm leading-relaxed text-zinc-700 dark:text-zinc-300 py-2.5 sm:py-3 px-3 sm:px-4 bg-zinc-50 dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800">
+                    {persona.persona_character}
+                  </div>
+                </div>
+              )}
+
+              {/* 인사이트와 숨겨진 니즈 통합 섹션 */}
+              {(persona.insight || persona.hiddenNeeds) && (
+                <div className="pb-4 sm:pb-5 border-b border-zinc-100 dark:border-zinc-800">
+                  <h3 className="text-xs sm:text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-2">
+                    핵심 니즈
+                  </h3>
+                  <div className="space-y-3">
+                    {persona.insight && (
+                      <div className="text-xs sm:text-sm leading-relaxed text-zinc-700 dark:text-zinc-300 py-2.5 sm:py-3 px-3 sm:px-4 bg-sky-50 dark:bg-sky-950/20 rounded-lg border border-sky-100 dark:border-sky-900/30">
+                        <span className="font-medium text-zinc-600 dark:text-zinc-400"></span> {persona.insight}
+                      </div>
+                    )}
+                    {persona.hiddenNeeds && (
+                      <div className="text-xs sm:text-sm leading-relaxed text-zinc-700 dark:text-zinc-300 py-2.5 sm:py-3 px-3 sm:px-4 bg-sky-50 dark:bg-sky-950/20 rounded-lg border border-sky-100 dark:border-sky-900/30">
+                        <span className="font-medium text-zinc-600 dark:text-zinc-400"></span> {persona.hiddenNeeds}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* 페인 포인트 - 토스 스타일 적용 */}
+              {persona.painPoint && (
+                <div className="pb-4 sm:pb-5 border-b border-zinc-100 dark:border-zinc-800">
+                  <h3 className="text-xs sm:text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-2">
+                    어려움
+                  </h3>
+                  <div className="text-xs sm:text-sm leading-relaxed text-zinc-700 dark:text-zinc-300 py-2.5 sm:py-3 px-3 sm:px-4 bg-rose-50 dark:bg-rose-950/20 rounded-lg border border-rose-100 dark:border-rose-900/30">
+                    {persona.painPoint}
+                  </div>
                 </div>
               )}
 
               {/* 키워드 섹션 - 토스 스타일 적용 */}
               {(persona.keywords || []).length > 0 && (
-                <div className="pb-4 sm:pb-5 border-b border-zinc-100 dark:border-zinc-800">
+                <div className="pb-0 sm:pb-4">
                   <h3 className="text-xs sm:text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-2">
                     키워드
                   </h3>
@@ -209,42 +242,6 @@ export default function ChatPage({ params }: ChatPageProps) {
                         {keyword}
                       </Badge>
                     ))}
-                  </div>
-                </div>
-              )}
-
-              {/* 페인 포인트 - 토스 스타일 적용 */}
-              {persona.painPoint && (
-                <div className="pb-4 sm:pb-5 border-b border-zinc-100 dark:border-zinc-800">
-                  <h3 className="text-xs sm:text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-2">
-                    내 어려움
-                  </h3>
-                  <div className="text-xs sm:text-sm leading-relaxed text-zinc-700 dark:text-zinc-300 py-2.5 sm:py-3 px-3 sm:px-4 bg-rose-50 dark:bg-rose-950/20 rounded-lg border border-rose-100 dark:border-rose-900/30">
-                    {persona.painPoint}
-                  </div>
-                </div>
-              )}
-              
-              {/* 숨겨진 니즈 - 토스 스타일 적용 */}
-              {persona.hiddenNeeds && (
-                <div className="pb-4 sm:pb-5 border-b border-zinc-100 dark:border-zinc-800">
-                  <h3 className="text-xs sm:text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-2">
-                    내 숨겨진 니즈
-                  </h3>
-                  <div className="text-xs sm:text-sm leading-relaxed text-zinc-700 dark:text-zinc-300 py-2.5 sm:py-3 px-3 sm:px-4 bg-sky-50 dark:bg-sky-950/20 rounded-lg border border-sky-100 dark:border-sky-900/30">
-                    {persona.hiddenNeeds}
-                  </div>
-                </div>
-              )}
-              
-              {/* 성격 및 말투 - 토스 스타일 적용 */}
-              {persona.persona_character && (
-                <div className="pb-0 sm:pb-4">
-                  <h3 className="text-xs sm:text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-2">
-                    성격 및 말투
-                  </h3>
-                  <div className="text-xs sm:text-sm leading-relaxed text-zinc-700 dark:text-zinc-300 py-2.5 sm:py-3 px-3 sm:px-4 bg-amber-50 dark:bg-amber-950/20 rounded-lg border border-amber-100 dark:border-amber-900/30">
-                    {persona.persona_character}
                   </div>
                 </div>
               )}

--- a/components/add-interview-modal.tsx
+++ b/components/add-interview-modal.tsx
@@ -4,7 +4,8 @@ import { useState, useRef } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { Upload, FileUp, File, X, Check, AlertCircle } from "lucide-react";
+import { Upload, FileUp, File, X, Check, AlertCircle, CheckCircle2 } from "lucide-react";
+import { motion } from "framer-motion";
 
 export interface AddInterviewModalProps {
   open: boolean;
@@ -140,14 +141,7 @@ export default function AddInterviewModal({ open, onOpenChange }: AddInterviewMo
       }
       
       setUploadSuccess(true);
-      
-      // 3초 후 모달 닫기
-      setTimeout(() => {
-        setFiles([]);
-        setIsUploading(false);
-        setUploadSuccess(false);
-        onOpenChange(false);
-      }, 3000);
+      setIsUploading(false);
     } catch (error: any) {
       console.error("처리 실패:", error);
       setError(error.message || '파일 처리 중 오류가 발생했습니다');
@@ -166,117 +160,167 @@ export default function AddInterviewModal({ open, onOpenChange }: AddInterviewMo
       }
     }}>
       <DialogContent className="sm:max-w-md md:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>고객 인터뷰 추가</DialogTitle>
-          <DialogDescription>
-            인터뷰 파일을 업로드하여 분석을 시작하세요.
-          </DialogDescription>
-        </DialogHeader>
-        
-        <div
-          className={`mt-2 border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
-            isDragging ? 'border-primary bg-primary/5' : 'border-border'
-          }`}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
-        >
-          <input
-            type="file"
-            ref={fileInputRef}
-            onChange={handleFileChange}
-            className="hidden"
-            accept=".txt,.md,.mdx,.markdown,.pdf,.html,.xlsx,.xls,.docx,.csv,.eml,.msg,.pptx,.ppt,.xml,.epub"
-          />
-          
-          <div className="flex flex-col items-center justify-center gap-2">
-            <Upload className="h-10 w-10 text-muted-foreground mb-2" />
-            <p className="text-sm font-medium">파일을 드래그하여 놓거나</p>
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={handleUploadClick}
-              className="mt-1"
+        {!uploadSuccess ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>고객 인터뷰 추가</DialogTitle>
+              <DialogDescription>
+                인터뷰 파일을 업로드하여 분석을 시작하세요.
+              </DialogDescription>
+            </DialogHeader>
+            
+            <div
+              className={`mt-2 border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
+                isDragging ? 'border-primary bg-primary/5' : 'border-border'
+              }`}
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
             >
-              <FileUp className="h-4 w-4 mr-2" />
-              파일 선택
-            </Button>
-            <p className="text-xs text-muted-foreground mt-2">
-              지원 형식: txt, md, mdx, markdown, pdf, html, xlsx, xls, docx, csv, eml, msg, pptx, ppt, xml, epub (최대 10MB)
-            </p>
-          </div>
-        </div>
-        
-        {files.length > 0 && (
-          <div className="mt-4">
-            <Label>첨부된 파일 ({files.length})</Label>
-            <div className="mt-2 space-y-2">
-              {files.map((file, index) => (
-                <div
-                  key={index}
-                  className="flex items-center justify-between bg-muted/50 p-2 rounded-md"
+              <input
+                type="file"
+                ref={fileInputRef}
+                onChange={handleFileChange}
+                className="hidden"
+                accept=".txt,.md,.mdx,.markdown,.pdf,.html,.xlsx,.xls,.docx,.csv,.eml,.msg,.pptx,.ppt,.xml,.epub"
+              />
+              
+              <div className="flex flex-col items-center justify-center gap-2">
+                <Upload className="h-10 w-10 text-muted-foreground mb-2" />
+                <p className="text-sm font-medium">파일을 드래그하여 놓거나</p>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={handleUploadClick}
+                  className="mt-1"
                 >
-                  <div className="flex items-center">
-                    <File className="h-4 w-4 mr-2 text-primary" />
-                    <span className="text-sm truncate max-w-[200px] md:max-w-[300px]">
-                      {file.name}
-                    </span>
-                    <span className="text-xs text-muted-foreground ml-2">
-                      {(file.size / 1024).toFixed(1)} KB
-                    </span>
-                  </div>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => handleRemoveFile(index)}
-                    className="h-7 w-7"
-                  >
-                    <X className="h-4 w-4" />
-                  </Button>
-                </div>
-              ))}
+                  <FileUp className="h-4 w-4 mr-2" />
+                  파일 선택
+                </Button>
+                <p className="text-xs text-muted-foreground mt-2">
+                  지원 형식: txt, md, mdx, markdown, pdf, html, xlsx, xls, docx, csv, eml, msg, pptx, ppt, xml, epub (최대 10MB)
+                </p>
+              </div>
             </div>
-          </div>
-        )}
-        
-        {error && (
-          <div className="p-3 flex items-start space-x-2 text-sm text-red-500 bg-red-50 rounded-md">
-            <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-            <span>{error}</span>
-          </div>
-        )}
-        
-        <DialogFooter className="flex-col sm:flex-row sm:justify-between sm:space-x-2">
-          <Button
-            variant="outline"
-            onClick={() => onOpenChange(false)}
-            disabled={isUploading}
-          >
-            취소
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={files.length === 0 || isUploading || !!error}
-            className="relative"
-          >
-            {isUploading && (
-              <span className="absolute inset-0 flex items-center justify-center">
-                <svg className="animate-spin h-5 w-5 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                </svg>
-              </span>
+            
+            {files.length > 0 && (
+              <div className="mt-4">
+                <Label>첨부된 파일 ({files.length})</Label>
+                <div className="mt-2 space-y-2">
+                  {files.map((file, index) => (
+                    <div
+                      key={index}
+                      className="flex items-center justify-between bg-muted/50 p-2 rounded-md"
+                    >
+                      <div className="flex items-center">
+                        <File className="h-4 w-4 mr-2 text-primary" />
+                        <span className="text-sm truncate max-w-[200px] md:max-w-[300px]">
+                          {file.name}
+                        </span>
+                        <span className="text-xs text-muted-foreground ml-2">
+                          {(file.size / 1024).toFixed(1)} KB
+                        </span>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleRemoveFile(index)}
+                        className="h-7 w-7"
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </div>
             )}
-            {uploadSuccess && (
-              <span className="absolute inset-0 flex items-center justify-center">
-                <Check className="h-5 w-5 text-current" />
-              </span>
+            
+            {error && (
+              <div className="p-3 flex items-start space-x-2 text-sm text-red-500 bg-red-50 rounded-md">
+                <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                <span>{error}</span>
+              </div>
             )}
-            <span className={isUploading || uploadSuccess ? 'opacity-0' : ''}>
-              분석하기
-            </span>
-          </Button>
-        </DialogFooter>
+            
+            <DialogFooter className="flex-col sm:flex-row sm:justify-between sm:space-x-2">
+              <Button
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isUploading}
+              >
+                취소
+              </Button>
+              <Button
+                onClick={handleSubmit}
+                disabled={files.length === 0 || isUploading || !!error}
+                className="relative"
+              >
+                {isUploading && (
+                  <span className="absolute inset-0 flex items-center justify-center">
+                    <svg className="animate-spin h-5 w-5 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                  </span>
+                )}
+                <span className={isUploading ? 'opacity-0' : ''}>
+                  분석하기
+                </span>
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <motion.div 
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.3 }}
+            className="flex flex-col items-center justify-center py-8 text-center"
+          >
+            <motion.div
+              initial={{ scale: 0, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ delay: 0.1, type: "spring", stiffness: 300, damping: 20 }}
+              className="bg-green-100 dark:bg-green-900/20 p-6 rounded-full mb-6"
+            >
+              <CheckCircle2 className="h-16 w-16 text-green-600 dark:text-green-400" />
+            </motion.div>
+            
+            <motion.h2
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2 }}
+              className="text-2xl font-bold mb-2"
+            >
+              업로드 성공!
+            </motion.h2>
+            
+            <motion.p
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.3 }}
+              className="text-muted-foreground mb-6"
+            >
+              고객 인터뷰 파일이 성공적으로 업로드되었습니다.
+            </motion.p>
+            
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.5 }}
+            >
+              <Button 
+                onClick={() => {
+                  setUploadSuccess(false);
+                  setFiles([]);
+                  onOpenChange(false);
+                }}
+                className="px-8"
+              >
+                확인
+              </Button>
+            </motion.div>
+          </motion.div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/components/persona-card-grid.tsx
+++ b/components/persona-card-grid.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button"
 import { Loader2, AlertOctagon, RefreshCw, SearchX, Plus } from "lucide-react"
 import { motion } from "framer-motion"
 import AddInterviewModal from "./add-interview-modal"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 
 interface Persona extends Omit<PersonaCardProps, 'summary'> {
   summary?: string;
@@ -157,16 +158,6 @@ export default function PersonaCardGrid() {
 
   return (
     <>
-      <div className="flex justify-end mb-4">
-        <Button 
-          onClick={() => setIsAddInterviewModalOpen(true)}
-          className="gap-1.5"
-        >
-          <Plus className="h-4 w-4" />
-          고객 인터뷰 추가
-        </Button>
-      </div>
-
       <motion.div 
         variants={container}
         initial="hidden"
@@ -189,6 +180,24 @@ export default function PersonaCardGrid() {
           </motion.div>
         ))}
       </motion.div>
+
+      {/* Floating Action Button - 우측 하단에 고정 배치 */}
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              onClick={() => setIsAddInterviewModalOpen(true)}
+              className="fixed bottom-8 right-8 rounded-full shadow-lg px-6 z-50"
+            >
+              <Plus className="h-5 w-5 mr-2" />
+              고객 인터뷰 추가
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            <p>새 고객 인터뷰 데이터 추가</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
 
       <AddInterviewModal 
         open={isAddInterviewModalOpen}

--- a/components/persona-switcher.tsx
+++ b/components/persona-switcher.tsx
@@ -37,7 +37,7 @@ export default function PersonaSwitcher({ currentPersona, allPersonas, currentPe
     <div className="space-y-3">
       {showHeader && (
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-medium text-zinc-700 dark:text-zinc-300">다른 페르소나</h3>
+          <h3 className="text-sm font-medium text-zinc-700 dark:text-zinc-300">다른 페르소나와 대화하기</h3>
         </div>
       )}
       

--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -179,7 +179,6 @@ export default function SearchBar() {
           animate={{ opacity: 1, y: 0 }}
           className="absolute right-5 -bottom-9 text-xs text-primary bg-background/80 px-2 py-1 rounded-md shadow-sm"
         >
-          <span>Enter 키를 눌러 AI에게 적합한 대화 상대를 추천받으세요</span>
         </motion.div>
       )}
     </motion.div>


### PR DESCRIPTION
1. 페르소나와 대화 화면 좌측 개선
* 상단 페르소나 summary 잘리지 않게 처리
    * 텍스트를 첫 문장만 표시하도록 수정
* 섹션 순서 및 레이아웃 재구성
    * 인사이트와 숨겨진 니즈를 통합하여 "핵심 니즈" 섹션으로 변경
    * 섹션 제목 간소화 ("내 어려움" → "어려움" 등)
* 페르소나 스위처의 헤더 텍스트를 "다른 페르소나와 대화하기"로 변경

2. [고객 인터뷰 추가] UI/UX 개선
- “고객 인터뷰 추가" 버튼을 우측 하단 플로팅 버튼으로 변경
* 인터뷰 업로드 성공 시 애니메이션이 있는 성공 화면 추가
* 검색바의 안내 텍스트 제거