### PR TITLE
Secure API key usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Miso API 설정
 MISO_API_URL=https://api.holdings.miso.gs
+# MISO_API_KEY에는 MISO 대시보드에서 발급받은 개인 키를 입력하세요
 MISO_API_KEY=your-miso-api-key-here
 
 # Supabase 설정

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ pnpm dev
 ```env
 # Miso API 설정
 MISO_API_URL=your-miso-endpoint-here
+# MISO_API_KEY는 MISO 대시보드에서 발급받은 개인 키를 입력합니다
 MISO_API_KEY=your-miso-api-key-here
 
 # Supabase 설정

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -14,12 +14,18 @@ export async function POST(req: NextRequest) {
 
 
   // MISO API 호출
+  const MISO_API_KEY = process.env.MISO_API_KEY
+
+  if (!MISO_API_KEY) {
+    return new Response('API 키가 설정되지 않았습니다.', { status: 500 })
+  }
+
   const upstream = await fetch(
     'https://api.holdings.miso.gs/ext/v1/chat',
     {
       method: 'POST',
       headers: {
-        Authorization: `Bearer app-2U7Nbl7pPsi3IEgET0HfomvT`,
+        Authorization: `Bearer ${MISO_API_KEY}`,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- fetch MISO API key from env in chat route
- document MISO API key in README and .env.example

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e375d2cc0832e8875762f4eee7c21