### PR TITLE
feat: Secure MISO API key and update documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Miso API 설정
+# MISO 서비스와 연동하기 위한 API 키입니다. MISO 플랫폼에서 발급받아 여기에 입력하세요.
 MISO_API_URL=https://api.holdings.miso.gs
 MISO_API_KEY=your-miso-api-key-here
 

--- a/README.md
+++ b/README.md
@@ -92,12 +92,17 @@ pnpm dev
 
 ```env
 # Miso API 설정
+# MISO 서비스와 연동하기 위한 API URL입니다. 일반적으로 https://api.holdings.miso.gs 입니다.
 MISO_API_URL=your-miso-endpoint-here
+# MISO 서비스와 연동하기 위한 API 키입니다. MISO 플랫폼의 API 설정에서 발급받아 여기에 입력하세요. 이 키가 없으면 AI 기능이 작동하지 않습니다.
 MISO_API_KEY=your-miso-api-key-here
 
 # Supabase 설정
+# Supabase 프로젝트 URL입니다. Supabase 대시보드의 프로젝트 설정에서 확인할 수 있습니다.
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+# Supabase 프로젝트의 익명 키(anon key)입니다. Supabase 대시보드의 API 설정에서 확인할 수 있습니다.
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
+# Supabase 프로젝트의 서비스 역할 키(service role key)입니다. Supabase 대시보드의 API 설정에서 확인할 수 있습니다. **이 키는 클라이언트에 노출되어서는 안 됩니다.**
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
 ```
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -4,6 +4,11 @@ export const runtime = 'edge'
 export const maxDuration = 30
 
 export async function POST(req: NextRequest) {
+  const MISO_API_KEY = process.env.MISO_API_KEY;
+
+  if (!MISO_API_KEY) {
+    return new Response('MISO_API_KEY is not configured.', { status: 500 });
+  }
   const { messages, personaData, conversationId: clientConversationId } = await req.json()
 
   if (!personaData) {
@@ -19,7 +24,7 @@ export async function POST(req: NextRequest) {
     {
       method: 'POST',
       headers: {
-        Authorization: `Bearer app-2U7Nbl7pPsi3IEgET0HfomvT`,
+        Authorization: `Bearer ${MISO_API_KEY}`,
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({


### PR DESCRIPTION
- Replaced hardcoded MISO API token in `app/api/chat/route.ts` with `process.env.MISO_API_KEY`.
- Added error handling in `app/api/chat/route.ts` to return a 500 error if `MISO_API_KEY` is not configured.
- Enhanced `.env.example` with a more descriptive comment for `MISO_API_KEY`.
- Updated `README.md` to provide clearer instructions on setting up `MISO_API_KEY` and other environment variables.

This change improves security by removing the hardcoded API key and provides better guidance for developers on configuring the application.